### PR TITLE
Make compilable on Linux

### DIFF
--- a/codebase/cow.cpp
+++ b/codebase/cow.cpp
@@ -2680,16 +2680,16 @@ void _mesh_draw(
 
     glBindVertexArray(COW0._mesh_VAO);
     unsigned int i_attrib = 0;
-    auto guarded_push = [&](void *array, int dim, int sizeof_type, int GL_TYPE) {
+    auto guarded_push = [&](void *array, int dim, int sizeof_type, int GL_TYPE_VAR) {
         ASSERT(i_attrib < ARRAY_LENGTH(COW0._mesh_VBO));
         glDisableVertexAttribArray(i_attrib);
         if (array) {
             glBindBuffer(GL_ARRAY_BUFFER, COW0._mesh_VBO[i_attrib]);
             glBufferData(GL_ARRAY_BUFFER, num_vertices * dim * sizeof_type, array, GL_DYNAMIC_DRAW);
-            if (GL_TYPE == GL_REAL) {
-                glVertexAttribPointer(i_attrib, dim, GL_TYPE, GL_FALSE, 0, NULL);
-            } else if (GL_TYPE == GL_INT) {
-                glVertexAttribIPointer(i_attrib, dim, GL_TYPE, 0, NULL);
+            if (GL_TYPE_VAR == GL_REAL) {
+                glVertexAttribPointer(i_attrib, dim, GL_TYPE_VAR, GL_FALSE, 0, NULL);
+            } else if (GL_TYPE_VAR == GL_INT) {
+                glVertexAttribIPointer(i_attrib, dim, GL_TYPE_VAR, 0, NULL);
             } else {
                 ASSERT(0);
             }
@@ -4576,10 +4576,10 @@ bool cow_begin_frame() {
                 }
                 if (COW0._cow_display_fps) {
                     static int fps;
-                    static std::chrono::steady_clock::time_point timestamp = std::chrono::high_resolution_clock::now();
-                    auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - timestamp);
+                    static std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
+                    auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - timestamp);
                     if (nanos.count() > 166666666 / 1.5) {
-                        timestamp = std::chrono::high_resolution_clock::now();
+                        timestamp = std::chrono::steady_clock::now();
                         fps = measured_fps;
                         // printf("fps: %d\n", display_fps);
                     }
@@ -4592,7 +4592,7 @@ bool cow_begin_frame() {
             {
                 const int N_MOVING_WINDOW = 5;
                 static std::chrono::steady_clock::time_point prev_timestamps[N_MOVING_WINDOW];
-                std::chrono::steady_clock::time_point timestamp = std::chrono::high_resolution_clock::now();
+                std::chrono::steady_clock::time_point timestamp = std::chrono::steady_clock::now();
                 auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(timestamp - prev_timestamps[N_MOVING_WINDOW - 1]);
                 measured_fps = (int) round(N_MOVING_WINDOW / (nanos.count() / 1000000000.));
 

--- a/cs345.cpp
+++ b/cs345.cpp
@@ -1,10 +1,6 @@
 #define _CRT_SECURE_NO_WARNINGS
 #define COW_USE_REAL_32
 
-#include "codebase/snail.cpp"
-#include "codebase/cow.cpp"
-#include "codebase/jim.cpp"
-
 #include <iostream>
 #include <fenv.h>
 #include <stdlib.h>
@@ -13,6 +9,10 @@
 #include <cstdio>
 #include <cstring>
 #include <cmath>
+
+#include "codebase/snail.cpp"
+#include "codebase/cow.cpp"
+#include "codebase/jim.cpp"
 
 typedef int8_t int8;
 typedef int16_t int16;


### PR DESCRIPTION
I've added a few fixes to make the codebase compilable on Linux (with both g++ and clang++).

## Compilations

The compilation commands are (I haven't updated the compile scripts):

g++: note that `-Wno-writable-strings` is clang-specific, so I used `-Wno-write-strings` instead.
```
g++ \
    dxfviewer.cpp \
    -o executable2 \
    -std=c++11 \
    -fno-strict-aliasing \
    -g \
    -Wall -Wextra \
    -Wshadow \
    -Werror=vla \
    -Wno-deprecated-declarations -Wno-missing-braces -Wno-missing-field-initializers -Wno-char-subscripts -Wno-write-strings \
    -I./codebase/ext \
    -L./codebase/ext \
    -lglfw -lGL \
    -lpthread
```

clang++: note that I have to add `-Wno-c++11-narrowing` to disable errors
```
clang++ \
    dxfviewer.cpp \
    -o executable \
    -std=c++11 \
    -fno-strict-aliasing \
    -g \
    -Wall -Wextra \
    -Wshadow \
    -Werror=vla \
    -Wno-deprecated-declarations -Wno-missing-braces -Wno-missing-field-initializers -Wno-char-subscripts -Wno-writable-strings -Wno-c++11-narrowing \
    -I./codebase/ext \
    -L./codebase/ext \
    -lglfw -lGL \
    -lpthread
```

## Changes

Detailed rationales follows:

### `GL_TYPE` => `GL_TYPE_VAR`

Error Message:

```
In file included from /usr/include/GL/gl.h:2050,
                 from codebase/ext/glfw3.h:241,
                 from codebase/cow.cpp:78,
                 from cs345.cpp:14,
                 from dxfviewer.cpp:1:
codebase/cow.cpp: In function ‘void _mesh_draw(cow_real*, cow_real*, cow_real*, int, int*, int, cow_real*, cow_real*, cow_real*, cow_real, cow_real, cow_real, cow_real*, char*, int, cow_real*, int*, cow_real*)’:
codebase/cow.cpp:2683:72: error: expected ‘,’ or ‘...’ before numeric constant
 2683 |     auto guarded_push = [&](void *array, int dim, int sizeof_type, int GL_TYPE) {
      |                                                                        ^~~~~~~
```

Analysis:
`GL_TYPE` is a defined macro in `/usr/include/GL/glext.h:2353` (line below, with `libglvnd 1.6.0-1`).

```
#define GL_TYPE                           0x92FA
```

Solution:
I've renamed the parameter to `GL_TYPE_VAR` to avoid the conflict.


### `high_resolution_clock` => `steady_clock`

Error Message:
```
In file included from cs345.cpp:14,
                 from dxfviewer.cpp:1:
codebase/cow.cpp: In function ‘bool cow_begin_frame()’:
codebase/cow.cpp:4579:117: error: conversion from ‘time_point<std::chrono::_V2::system_clock,[...]>’ to non-scalar type ‘time_point<std::chrono::_V2::steady_clock,[...]>’ requested
 4579 |                     static std::chrono::steady_clock::time_point timestamp = std::chrono::high_resolution_clock::now();
      |                                                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
codebase/cow.cpp:4580:129: error: no match for ‘operator-’ (operand types are ‘std::chrono::_V2::system_clock::time_point’ {aka ‘std::chrono::time_point<std::chrono::_V2::system_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >’} and ‘std::chrono::_V2::steady_clock::time_point’ {aka ‘std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long int, std::ratio<1, 1000000000> > >’})
 4580 |                     auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - timestamp);
      |                                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~
      |                                                                                                                              |    |
      |                                                                                                                              |    time_point<std::chrono::_V2::steady_clock,[...]>
      |                                                                                                                              time_point<std::chrono::_V2::system_clock,[...]>
```

Analysis:
It seems that on Linux, `high_resolution_clock` is a synonym for `system_clock` (on other platforms it may be for `steady_clock`). The latter is really what we want here.

Solution:
Renaming to use `steady_clock` explicitly.

### Reorder includes in `cow.cpp`

Error Message:
```
In file included from cs345.cpp:6,
                 from dxfviewer.cpp:1:
codebase/jim.cpp:63:23: error: variable or field ‘defer_’ declared void
   63 | #define __defer(line) defer_ ## line
      |                       ^~~~~~
In file included from /usr/include/c++/13.2.1/x86_64-pc-linux-gnu/bits/gthr-default.h:35,
                 from /usr/include/c++/13.2.1/x86_64-pc-linux-gnu/bits/gthr.h:148,
                 from /usr/include/c++/13.2.1/ext/atomicity.h:35,
                 from /usr/include/c++/13.2.1/bits/ios_base.h:39,
                 from /usr/include/c++/13.2.1/ios:44,
                 from /usr/include/c++/13.2.1/ostream:40,
                 from /usr/include/c++/13.2.1/iostream:41,
                 from cs345.cpp:8:
/usr/include/pthread.h:581:61: error: expected ‘;’ at end of member declaration
  581 |                                            &__cancel_type); }
      |                                                             ^
      |                                                              ;
cc1plus: note: unrecognized command-line option ‘-Wno-writable-strings’ may have been intended to silence earlier diagnostics
```

Analysis:
In `cs345.cpp`, `jim.cpp` is included before `iostream.cpp`. Hence, the `__defer` macro defined in `jim.cpp` overwrites the `__defer` function declared in `pthread` (see below).
```
  void __defer () { pthread_setcanceltype (PTHREAD_CANCEL_DEFERRED,
					   &__cancel_type); }
```
